### PR TITLE
Extra spaces in nfvis.py caused error

### DIFF
--- a/verify/backend/nfvis.py
+++ b/verify/backend/nfvis.py
@@ -78,7 +78,7 @@ def verify() -> bool:
     else:
         pingstatus = "Ping Failed"
         print("  " + pingstatus)
-            return False
+        return False
     
     # Test: Is the REST API running
     r = nfv_get_networks_configuration(s, url)


### PR DESCRIPTION
==> Verifying access to the Meraki APIs
Traceback (most recent call last):
  File "verify.py", line 81, in <module>
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 674, in exec_module
  File "<frozen importlib._bootstrap_external>", line 781, in get_code
  File "<frozen importlib._bootstrap_external>", line 741, in source_to_code
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/developer/code/dnav3-code/verify/backend/nfvis.py", line 81
    return False
    ^
IndentationError: unexpected indent