### PR TITLE
Updated requirements.txt to include xmltodict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ ciscosparkapi
 netmiko
 ncclient
 requests
+xmltodict


### PR DESCRIPTION
`intro-mdp/netconf/get_interface_list.py` requires the `xmltodict` module.

Discovered issue while going through this track: https://learninglabs.cisco.com/tracks/dnav3-track/dnav3-intro-dnac/dnav3-intro-netconf/step/4