### PR TITLE
Wrong amount of args passed to pasrsecommand()

### DIFF
--- a/intro-meraki/meraki-05-mission/mxfirewallcontrol.py
+++ b/intro-meraki/meraki-05-mission/mxfirewallcontrol.py
@@ -491,7 +491,7 @@ def main(argv):
 
     # parse and execute command
     parsecommand(
-        arg_apikey, orglist, arg_command
+        arg_apikey, orglist, arg_command, None, None
     )
 
     printusertext("INFO: End of script.")


### PR DESCRIPTION
Since parsecommand takes 5 arguments, it should also be called with 5. Temporary fix so that the code runs.

