### PR TITLE
Enhanced output on graph. When using previous value "name", a ASR1001…

### DIFF
--- a/intro-dnac/dnac-nbapi-mission/mission.py
+++ b/intro-dnac/dnac-nbapi-mission/mission.py
@@ -218,7 +218,7 @@ with requests.Session() as dnac_session:
                 next_data['nodes'].append({'id ': i,
                                            'x': (i*20),
                                            'y': 20*(i-di+1),
-                                           'name': m['partNumber'],
+                                           'name': m['description'],
                                            'serial': d['serialNumber'],
                                            'icon': 'server'})
                 next_data['links'].append({'source': di, 'target': i})


### PR DESCRIPTION
…X, will have mulitple "ASR1001X"-modules which is not very informative. Using "description" provides more information such as "ASR1001 Route processor" and "SPA interface" 