### PR TITLE
Changed XML tag for Interface - from interface to interfaces.

### DIFF
--- a/intro-mdp/mission01/netconf_functions.py
+++ b/intro-mdp/mission01/netconf_functions.py
@@ -37,7 +37,7 @@ def check_ip(device):
         <interface>
             <name>GigabitEthernet2</name>
         </interface>
-      </interface>
+      </interfaces>
     </MISSION>"""
     # END MISSION SECTION
 

--- a/intro-mdp/netconf/get_interface_list.py
+++ b/intro-mdp/netconf/get_interface_list.py
@@ -46,7 +46,7 @@ netconf_filter = """
 <filter>
   <interfaces xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces">
     <interface></interface>
-  </interface>
+  </interfaces>
 </filter>"""
 
 print("Opening NETCONF Connection to {}".format(env_lab.IOS_XE_1["host"]))


### PR DESCRIPTION
The XML filter was incorrect and was thus throwing an XML error.
lxml.etree.XMLSyntaxError: Opening and ending tag mismatch: interfaces line 3 and interface, line 5, column 24

To correct this error /interface was changed to /interfaces
This error was in get_interface_list.py and netconf_functions.py