### PR TITLE
Fixed issue 33

### DIFF
--- a/intro-mdp/netconf/get_interface_list.py
+++ b/intro-mdp/netconf/get_interface_list.py
@@ -46,7 +46,7 @@ netconf_filter = """
 <filter>
   <interfaces xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces">
     <interface></interface>
-  </interface>
+  </interfaces>
 </filter>"""
 
 print("Opening NETCONF Connection to {}".format(env_lab.IOS_XE_1["host"]))


### PR DESCRIPTION
Just added an 's' to the closing interfaces tag in get_interface_list.py. Getting an XMLSyntax error prior to the change. More details in issue 33.
