### PR TITLE
Updating ncclient to support 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ciscosparkapi==0.9.2
-ncclient==0.5.3
+ncclient==0.6.0
 netmiko==1.4.2
 pyang==1.7.4
 requests==2.18.4


### PR DESCRIPTION
Still need to regression test this on mdp lab, but it was fine for ansible with py 3.6 and 3.7.