### PR TITLE
Fix/postman restconf

### DIFF
--- a/dev/tunnel-ssl-ios-xe-mgmt.cisco.com.sh
+++ b/dev/tunnel-ssl-ios-xe-mgmt.cisco.com.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Used because Chrome now requires SSL certs to have Subject Alternatic Name set,
+# and as of 2018-08-23 the cert on ios-xe-mgmt.cisco.com does not have such
+# Hence we need Postman to connect via this socat tunnel, which will do the SSL with unverified cert
+echo 'Forwarding http://127.0.0.1:9443 -> https://ios-xe-mgmt.cisco.com:9443'
+socat TCP-LISTEN:9443,fork,reuseaddr,bind=127.0.0.1 OPENSSL:ios-xe-mgmt.cisco.com:9443,verify=0

--- a/postman/DevNet Learning Labs- Intro to Model Driven Programmability.postman_collection.json
+++ b/postman/DevNet Learning Labs- Intro to Model Driven Programmability.postman_collection.json
@@ -13,31 +13,6 @@
 				{
 					"name": "Read the top level REST resource",
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [
 							{
@@ -50,7 +25,7 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic dmFncmFudDp2YWdyYW50"
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							}
 						],
 						"body": {
@@ -58,8 +33,8 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/.well-known/host-meta",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/.well-known/host-meta",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -76,31 +51,6 @@
 				{
 					"name": "Read Top Level RESTCONF",
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [
 							{
@@ -113,13 +63,13 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic dmFncmFudDp2YWdyYW50"
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							}
 						],
 						"body": {},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -146,31 +96,6 @@
 						}
 					],
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [
 							{
@@ -183,7 +108,7 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic dmFncmFudDp2YWdyYW50"
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							}
 						],
 						"body": {
@@ -191,8 +116,8 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf/data/netconf-state/capabilities",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf/data/netconf-state/capabilities",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -222,31 +147,6 @@
 						}
 					],
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [
 							{
@@ -259,13 +159,13 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic dmFncmFudDp2YWdyYW50"
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							}
 						],
 						"body": {},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf/data/ietf-yang-library:modules-state",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf/data/ietf-yang-library:modules-state",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -283,31 +183,6 @@
 				{
 					"name": "Read ietf-interfaces list of interfaces",
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [
 							{
@@ -320,13 +195,13 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic dmFncmFudDp2YWdyYW50"
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							}
 						],
 						"body": {},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf/data/ietf-interfaces:interfaces",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf/data/ietf-interfaces:interfaces",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -344,31 +219,6 @@
 				{
 					"name": "Read ietf-interfaces single interface",
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [
 							{
@@ -381,13 +231,13 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic dmFncmFudDp2YWdyYW50"
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							}
 						],
 						"body": {},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf/data/ietf-interfaces:interfaces/interface=GigabitEthernet2",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf/data/ietf-interfaces:interfaces/interface=GigabitEthernet2",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -406,36 +256,11 @@
 				{
 					"name": "Configure ietf-interfaces single interface",
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic cm9vdDpjaXNjbzEyMw=="
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							},
 							{
 								"key": "Accept",
@@ -451,8 +276,8 @@
 							"raw": "{\n    \"ietf-interfaces:interface\": {\n        \"name\": \"GigabitEthernet2\",\n        \"description\": \"Configured by RESTCONF\",\n        \"type\": \"iana-if-type:ethernetCsmacd\",\n        \"enabled\": true,\n        \"ietf-ip:ipv4\": {\n            \"address\": [\n                {\n                    \"ip\": \"10.255.255.1\",\n                    \"netmask\": \"255.255.255.0\"\n                }\n            ]\n        }\n    }\n}"
 						},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf/data/ietf-interfaces:interfaces/interface=GigabitEthernet2",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf/data/ietf-interfaces:interfaces/interface=GigabitEthernet2",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -470,36 +295,11 @@
 				{
 					"name": "Add new loopback interface",
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic cm9vdDpjaXNjbzEyMw=="
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							},
 							{
 								"key": "Accept",
@@ -515,8 +315,8 @@
 							"raw": "{\n    \"ietf-interfaces:interface\": {\n        \"name\": \"Loopback100\",\n        \"description\": \"Configured by RESTCONF\",\n        \"type\": \"iana-if-type:softwareLoopback\",\n        \"enabled\": true,\n        \"ietf-ip:ipv4\": {\n            \"address\": [\n                {\n                    \"ip\": \"172.16.100.1\",\n                    \"netmask\": \"255.255.255.0\"\n                }\n            ]\n        }\n    }\n}"
 						},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf/data/ietf-interfaces:interfaces",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf/data/ietf-interfaces:interfaces",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -533,31 +333,6 @@
 				{
 					"name": "Delete Loopback Interface",
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "DELETE",
 						"header": [
 							{
@@ -570,13 +345,13 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic dmFncmFudDp2YWdyYW50"
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							}
 						],
 						"body": {},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf/data/ietf-interfaces:interfaces/interface=Loopback100",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf/data/ietf-interfaces:interfaces/interface=Loopback100",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -595,31 +370,6 @@
 				{
 					"name": "Read native device single interface",
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [
 							{
@@ -632,13 +382,13 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic dmFncmFudDp2YWdyYW50"
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							}
 						],
 						"body": {},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf/data/Cisco-IOS-XE-native:native/interface/GigabitEthernet=2",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf/data/Cisco-IOS-XE-native:native/interface/GigabitEthernet=2",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -658,31 +408,6 @@
 				{
 					"name": "Operational State interfaces",
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [
 							{
@@ -695,7 +420,7 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic dmFncmFudDp2YWdyYW50"
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							}
 						],
 						"body": {
@@ -703,8 +428,8 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf/data/ietf-interfaces:interfaces-state/",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf/data/ietf-interfaces:interfaces-state/",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -722,36 +447,11 @@
 				{
 					"name": "Read native hostname",
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic cm9vdDpjaXNjbzEyMw=="
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							},
 							{
 								"key": "Content-Type",
@@ -767,8 +467,8 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf/data/Cisco-IOS-XE-native:native/hostname",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf/data/Cisco-IOS-XE-native:native/hostname",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -797,31 +497,6 @@
 						}
 					],
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [
 							{
@@ -834,13 +509,13 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic dmFncmFudDp2YWdyYW50"
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							}
 						],
 						"body": {},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf/data/ietf-yang-library:modules-state",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf/data/ietf-yang-library:modules-state",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -869,31 +544,6 @@
 						}
 					],
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [
 							{
@@ -906,13 +556,13 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic dmFncmFudDp2YWdyYW50"
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							}
 						],
 						"body": {},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf/data/ietf-restconf-monitoring:restconf-state/capabilities",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf/data/ietf-restconf-monitoring:restconf-state/capabilities",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -931,31 +581,6 @@
 				{
 					"name": "Filter Fields Returned in Response",
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [
 							{
@@ -968,13 +593,13 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic dmFncmFudDp2YWdyYW50"
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							}
 						],
 						"body": {},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf/data/Cisco-IOS-XE-native:native/interface/GigabitEthernet=2?fields=Cisco-IOS-XE-native:GigabitEthernet(name;description;ip)&depth=unbounded",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf/data/Cisco-IOS-XE-native:native/interface/GigabitEthernet=2?fields=Cisco-IOS-XE-native:GigabitEthernet(name;description;ip)&depth=unbounded",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
@@ -1017,31 +642,6 @@
 						}
 					],
 					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "{{username}}",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "{{password}}",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"value": true,
-									"type": "boolean"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
 						"method": "POST",
 						"header": [
 							{
@@ -1054,13 +654,13 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic dmFncmFudDp2YWdyYW50"
+								"value": "Basic cm9vdDpEX1ZheSFfMTAm"
 							}
 						],
 						"body": {},
 						"url": {
-							"raw": "https://{{host}}:{{port}}/restconf/operations/cisco-ia:save-config/",
-							"protocol": "https",
+							"raw": "http://{{host}}:{{port}}/restconf/operations/cisco-ia:save-config/",
+							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],

--- a/postman/DevNet Sandbox RESTCONF Always On.postman_environment.json
+++ b/postman/DevNet Sandbox RESTCONF Always On.postman_environment.json
@@ -5,25 +5,13 @@
     {
       "enabled": true,
       "key": "host",
-      "value": "ios-xe-mgmt.cisco.com",
+      "value": "localhost",
       "type": "text"
     },
     {
       "enabled": true,
       "key": "port",
       "value": "9443",
-      "type": "text"
-    },
-    {
-      "enabled": true,
-      "key": "username",
-      "value": "root",
-      "type": "text"
-    },
-    {
-      "enabled": true,
-      "key": "password",
-      "value": "D_Vay!_10&",
       "type": "text"
     }
   ],


### PR DESCRIPTION
While going through the course for intro to restconf (https://learninglabs.cisco.com/lab/intro-restconf/step/1), postman was failing to talk to the always-on restconf sandbox.
Turned out the reason was SSL cert not having Subject Alternative Name set.
Did a writeup with more detail here: https://medium.com/@nick.p.doyle/cisco-developer-sandbox-self-signed-certs-disliked-by-chrome-a872ee9e41e0
Until the cert gets updated (ideal situation) my workaround is to access via socat tunnel with --verify=0

Also - postman was resetting request auth each time I made a request, because the basic auth was set ... seems like a postman bug to me, but I took the opportunity to remove the postman collection request.auth elements, and update Authorization: header to the correct one.

**dev/tunnel-ssl-ios-xe-mgmt.cisco.com.sh**
 New script to stand up the socat tunnel from localhost to the always-on sandbox

**DevNet Learning Labs- Intro to Model Driven Programmability.postman_collection.json**
Set 'Authorization:' header correctly (some requests were using "cm9vdDpjaXNjbzEyMw==" ("root:cisco123"))
Switch to plain http (since now via socat tunnel)
Remove request.auth elements since with new postman version they were causing auth to get reset when request made -and now we are hardcoding Authorization: header

**DevNet Sandbox RESTCONF Always On.postman_environment.json**
host=localhost (use tunnel)
Remove username and password since no longer used