### PR TITLE
Update ncclient to 0.6.2 for verify folder

### DIFF
--- a/verify/requirements.txt
+++ b/verify/requirements.txt
@@ -1,5 +1,5 @@
 ciscosparkapi==0.9.2
-ncclient==0.5.3
+ncclient==0.6.2
 netmiko==1.4.2
 requests==2.18.4
 urllib3==1.22


### PR DESCRIPTION
Updating ncclient in the requirements.txt for this folder, as well, in case some people do the `pip install` from this folder instead of the root level folder. See #35, #44 