### PR TITLE
Remove count parameter from ping command (which doesnt work in Windows)

### DIFF
--- a/verify/backend/iosxe.py
+++ b/verify/backend/iosxe.py
@@ -68,7 +68,7 @@ def verify() -> bool:
         print("Testing Device {}".format(device["host"]))
         # Test: Is device pingable
         response = os.system(
-            "ping -c 2 {} >> iosxe_tests.txt".format(device["host"])
+            "ping {} >> iosxe_tests.txt".format(device["host"])
         )
         # and then check the response...
         if response == 0:

--- a/verify/backend/nfvis.py
+++ b/verify/backend/nfvis.py
@@ -69,7 +69,7 @@ def verify() -> bool:
 
     # Test: Is device pingable
     response = os.system(
-        "ping -c 2 {} >> nfvis_tests.txt".format(nip)
+        "ping {} >> nfvis_tests.txt".format(nip)
     )
     # and then check the response...
     if response == 0:


### PR DESCRIPTION
I have an error running ping with -c paramenter in Windows 10 because of Access rights initially and later beacuse of missuse of the parameter

Related to #53 