### PR TITLE
upgrade ncclient from 0.5.3 to 0.6.4

### DIFF
--- a/intro-mdp/requirements.txt
+++ b/intro-mdp/requirements.txt
@@ -1,5 +1,5 @@
 ciscosparkapi==0.9.2
-ncclient==0.5.3
+ncclient==0.6.4
 netmiko==1.4.2
 pyang==1.7.4
 requests==2.18.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ciscosparkapi==0.9.2
 ncclient==0.6.0
 netmiko==1.4.2
 pyang==1.7.4
-requests==2.18.4
-urllib3==1.22
+requests==2.20.0
+urllib3==1.24.2
 xmltodict==0.11.0
 ansible==2.5.4


### PR DESCRIPTION
The code samples in the ./netconf directory do not work with 0.5.3. They do work with 0.6.4.
The following log file demonstrates this.

ECKELCU-M-H15L:ripe78 eckelcu$ cd dnav3-code/
ECKELCU-M-H15L:dnav3-code eckelcu$ cd intro-mdp/
ECKELCU-M-H15L:intro-mdp eckelcu$ python3 -m venv venv
ECKELCU-M-H15L:intro-mdp eckelcu$ source venv/bin/activate
(venv) ECKELCU-M-H15L:intro-mdp eckelcu$ pip install -r requirements.txt
Collecting ciscosparkapi==0.9.2 (from -r requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/44/1f/a380c764951a577d894733c42662286b2ddfaba4d5d6559a13dbb5049f84/ciscosparkapi-0.9.2.tar.gz
Collecting ncclient==0.5.3 (from -r requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/e9/cf/cb131bcaf9b31f8d9d1b9ec3aa9a861dd72a7269a9ff07217b60157fa526/ncclient-0.5.3.tar.gz
Collecting netmiko==1.4.2 (from -r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/d5/3f/8da410e8474c50a31265165f5197b3aad170560b1947970d375e72b1572f/netmiko-1.4.2.tar.gz
Collecting pyang==1.7.4 (from -r requirements.txt (line 4))
  Using cached https://files.pythonhosted.org/packages/6d/b3/4726a0dbd07202364207d2992214c78a934f0dd6bf491051706afe3e2744/pyang-1.7.4-py2.py3-none-any.whl
Collecting requests==2.18.4 (from -r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/49/df/50aa1999ab9bde74656c2919d9c0c085fd2b3775fd3eca826012bef76d8c/requests-2.18.4-py2.py3-none-any.whl
Collecting urllib3==1.22 (from -r requirements.txt (line 6))
  Using cached https://files.pythonhosted.org/packages/63/cb/6965947c13a94236f6d4b8223e21beb4d576dc72e8130bd7880f600839b8/urllib3-1.22-py2.py3-none-any.whl
Collecting xmltodict==0.11.0 (from -r requirements.txt (line 7))
  Using cached https://files.pythonhosted.org/packages/42/a9/7e99652c6bc619d19d58cdd8c47560730eb5825d43a7e25db2e1d776ceb7/xmltodict-0.11.0-py2.py3-none-any.whl
Collecting future (from ciscosparkapi==0.9.2->-r requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/90/52/e20466b85000a181e1e144fd8305caf2cf475e2f9674e797b222f8105f5f/future-0.17.1.tar.gz
Collecting requests-toolbelt (from ciscosparkapi==0.9.2->-r requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/60/ef/7681134338fc097acef8d9b2f8abe0458e4d87559c689a8c306d0957ece5/requests_toolbelt-0.9.1-py2.py3-none-any.whl
Requirement already satisfied: setuptools>0.6 in ./venv/lib/python3.7/site-packages (from ncclient==0.5.3->-r requirements.txt (line 2)) (39.0.1)
Collecting paramiko>=1.15.0 (from ncclient==0.5.3->-r requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/cf/ae/94e70d49044ccc234bfdba20114fa947d7ba6eb68a2e452d89b920e62227/paramiko-2.4.2-py2.py3-none-any.whl
Collecting lxml>=3.3.0 (from ncclient==0.5.3->-r requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/45/6c/436a534dca42f7982ba793983353035d117ab70541266704974efa323ade/lxml-4.3.3-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
Collecting six (from ncclient==0.5.3->-r requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Collecting scp>=0.10.0 (from netmiko==1.4.2->-r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/4d/7a/3d76dc5ad8deea79642f50a572e1c057cb27e8b427f83781a2c05ce4e5b6/scp-0.13.2-py2.py3-none-any.whl
Collecting pyyaml (from netmiko==1.4.2->-r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/9f/2c/9417b5c774792634834e730932745bc09a7d36754ca00acf1ccd1ac2594d/PyYAML-5.1.tar.gz
Collecting chardet<3.1.0,>=3.0.2 (from requests==2.18.4->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
Collecting certifi>=2017.4.17 (from requests==2.18.4->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/60/75/f692a584e85b7eaba0e03827b3d51f45f571c2e793dd731e598828d380aa/certifi-2019.3.9-py2.py3-none-any.whl
Collecting idna<2.7,>=2.5 (from requests==2.18.4->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/27/cc/6dd9a3869f15c2edfab863b992838277279ce92663d334df9ecf5106f5c6/idna-2.6-py2.py3-none-any.whl
Collecting cryptography>=1.5 (from paramiko>=1.15.0->ncclient==0.5.3->-r requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/12/cd/f2c4dac6e48add01d4575e8fd8ca9a16f4236afe321e6e5ffdc7a4725b55/cryptography-2.6.1-cp34-abi3-macosx_10_6_intel.whl
Collecting pyasn1>=0.1.7 (from paramiko>=1.15.0->ncclient==0.5.3->-r requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/7b/7c/c9386b82a25115cccf1903441bba3cbadcfae7b678a20167347fa8ded34c/pyasn1-0.4.5-py2.py3-none-any.whl
Collecting pynacl>=1.0.1 (from paramiko>=1.15.0->ncclient==0.5.3->-r requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/cd/c9/4d6deea9d900345b1243cc3e6265110697fae5e594689cfa1ba34e0ef4a8/PyNaCl-1.3.0-cp34-abi3-macosx_10_6_intel.whl
Collecting bcrypt>=3.1.3 (from paramiko>=1.15.0->ncclient==0.5.3->-r requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/c8/05/e51ab21c47981eb554a94a7b5af9e61f82640dec99713cd3b359c91ff39e/bcrypt-3.1.6-cp34-abi3-macosx_10_6_intel.whl
Collecting asn1crypto>=0.21.0 (from cryptography>=1.5->paramiko>=1.15.0->ncclient==0.5.3->-r requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl
Collecting cffi!=1.11.3,>=1.8 (from cryptography>=1.5->paramiko>=1.15.0->ncclient==0.5.3->-r requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/f0/48/5aa4ea664eba26dd5142558d04762f5065c02220b4665b3f7eecb9bb614e/cffi-1.12.3-cp37-cp37m-macosx_10_9_x86_64.whl
Collecting pycparser (from cffi!=1.11.3,>=1.8->cryptography>=1.5->paramiko>=1.15.0->ncclient==0.5.3->-r requirements.txt (line 2))
Installing collected packages: future, chardet, certifi, urllib3, idna, requests, requests-toolbelt, ciscosparkapi, asn1crypto, pycparser, cffi, six, cryptography, pyasn1, pynacl, bcrypt, paramiko, lxml, ncclient, scp, pyyaml, netmiko, pyang, xmltodict
  Running setup.py install for future ... done
  Running setup.py install for ciscosparkapi ... done
  Running setup.py install for ncclient ... done
  Running setup.py install for pyyaml ... done
  Running setup.py install for netmiko ... done
Successfully installed asn1crypto-0.24.0 bcrypt-3.1.6 certifi-2019.3.9 cffi-1.12.3 chardet-3.0.4 ciscosparkapi-0.9.2 cryptography-2.6.1 future-0.17.1 idna-2.6 lxml-4.3.3 ncclient-0.5.3 netmiko-1.4.2 paramiko-2.4.2 pyang-1.7.4 pyasn1-0.4.5 pycparser-2.19 pynacl-1.3.0 pyyaml-5.1 requests-2.18.4 requests-toolbelt-0.9.1 scp-0.13.2 six-1.12.0 urllib3-1.22 xmltodict-0.11.0
You are using pip version 10.0.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
(venv) ECKELCU-M-H15L:intro-mdp eckelcu$ cd netconf
(venv) ECKELCU-M-H15L:netconf eckelcu$ python get_interface_list.py 
Traceback (most recent call last):
  File "get_interface_list.py", line 28, in <module>
    from ncclient import manager
  File "/Users/eckelcu/ripe78/dnav3-code/intro-mdp/venv/lib/python3.7/site-packages/ncclient/manager.py", line 230
    async=self._async_mode,
        ^
SyntaxError: invalid syntax
(venv) ECKELCU-M-H15L:netconf eckelcu$ pip install --upgrade ncclient
Collecting ncclient
  Using cached https://files.pythonhosted.org/packages/22/4d/05b21cc52eedb44f994600ed527e4dda3fcb6f4c1e0e9c6aa8f72348131a/ncclient-0.6.4.tar.gz
Requirement not upgraded as not directly required: setuptools>0.6 in /Users/eckelcu/ripe78/dnav3-code/intro-mdp/venv/lib/python3.7/site-packages (from ncclient) (39.0.1)
Requirement not upgraded as not directly required: paramiko>=1.15.0 in /Users/eckelcu/ripe78/dnav3-code/intro-mdp/venv/lib/python3.7/site-packages (from ncclient) (2.4.2)
Requirement not upgraded as not directly required: lxml>=3.3.0 in /Users/eckelcu/ripe78/dnav3-code/intro-mdp/venv/lib/python3.7/site-packages (from ncclient) (4.3.3)
Requirement not upgraded as not directly required: six in /Users/eckelcu/ripe78/dnav3-code/intro-mdp/venv/lib/python3.7/site-packages (from ncclient) (1.12.0)
Requirement not upgraded as not directly required: bcrypt>=3.1.3 in /Users/eckelcu/ripe78/dnav3-code/intro-mdp/venv/lib/python3.7/site-packages (from paramiko>=1.15.0->ncclient) (3.1.6)
Requirement not upgraded as not directly required: pynacl>=1.0.1 in /Users/eckelcu/ripe78/dnav3-code/intro-mdp/venv/lib/python3.7/site-packages (from paramiko>=1.15.0->ncclient) (1.3.0)
Requirement not upgraded as not directly required: cryptography>=1.5 in /Users/eckelcu/ripe78/dnav3-code/intro-mdp/venv/lib/python3.7/site-packages (from paramiko>=1.15.0->ncclient) (2.6.1)
Requirement not upgraded as not directly required: pyasn1>=0.1.7 in /Users/eckelcu/ripe78/dnav3-code/intro-mdp/venv/lib/python3.7/site-packages (from paramiko>=1.15.0->ncclient) (0.4.5)
Requirement not upgraded as not directly required: cffi>=1.1 in /Users/eckelcu/ripe78/dnav3-code/intro-mdp/venv/lib/python3.7/site-packages (from bcrypt>=3.1.3->paramiko>=1.15.0->ncclient) (1.12.3)
Requirement not upgraded as not directly required: asn1crypto>=0.21.0 in /Users/eckelcu/ripe78/dnav3-code/intro-mdp/venv/lib/python3.7/site-packages (from cryptography>=1.5->paramiko>=1.15.0->ncclient) (0.24.0)
Requirement not upgraded as not directly required: pycparser in /Users/eckelcu/ripe78/dnav3-code/intro-mdp/venv/lib/python3.7/site-packages (from cffi>=1.1->bcrypt>=3.1.3->paramiko>=1.15.0->ncclient) (2.19)
Installing collected packages: ncclient
  Found existing installation: ncclient 0.5.3
    Uninstalling ncclient-0.5.3:
      Successfully uninstalled ncclient-0.5.3
  Running setup.py install for ncclient ... done
Successfully installed ncclient-0.6.4
You are using pip version 10.0.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
(venv) ECKELCU-M-H15L:netconf eckelcu$ python get_interface_list.py 
Opening NETCONF Connection to ios-xe-mgmt.cisco.com
Sending a <get-config> operation to the device.

Here is the raw XML data returned from the device.

<?xml version="1.0" ?>
<rpc-reply message-id="urn:uuid:5133d1f3-9476-4cd5-b0f5-badea6fab16c" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
    <data>
        <interfaces xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces">
            <interface>
                <name>GigabitEthernet1</name>
                <description>DON'T TOUCH ME</description>
                <type xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">ianaift:ethernetCsmacd</type>
                <enabled>true</enabled>
                <ipv4 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip">
                    <address>
                        <ip>10.10.20.48</ip>
                        <netmask>255.255.255.0</netmask>
                    </address>
                </ipv4>
                <ipv6 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip"/>
            </interface>
            <interface>
                <name>GigabitEthernet2</name>
                <description>Configured by NETCONF</description>
                <type xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">ianaift:ethernetCsmacd</type>
                <enabled>true</enabled>
                <ipv4 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip">
                    <address>
                        <ip>10.255.255.1</ip>
                        <netmask>255.255.255.0</netmask>
                    </address>
                </ipv4>
                <ipv6 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip"/>
            </interface>
            <interface>
                <name>GigabitEthernet3</name>
                <type xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">ianaift:ethernetCsmacd</type>
                <enabled>false</enabled>
                <ipv4 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip"/>
                <ipv6 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip"/>
            </interface>
            <interface>
                <name>Loopback0</name>
                <description>BY RESTCONF POSTMAN</description>
                <type xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">ianaift:softwareLoopback</type>
                <enabled>true</enabled>
                <ipv4 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip">
                    <address>
                        <ip>222.222.222.222</ip>
                        <netmask>255.255.255.255</netmask>
                    </address>
                </ipv4>
                <ipv6 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip"/>
            </interface>
            <interface>
                <name>Loopback201</name>
                <description>Configured by pyATS</description>
                <type xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">ianaift:softwareLoopback</type>
                <enabled>true</enabled>
                <ipv4 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip">
                    <address>
                        <ip>172.16.201.1</ip>
                        <netmask>255.255.255.0</netmask>
                    </address>
                </ipv4>
                <ipv6 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip"/>
            </interface>
            <interface>
                <name>Loopback1919</name>
                <description>Configured via NETCONF</description>
                <type xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">ianaift:softwareLoopback</type>
                <enabled>true</enabled>
                <ipv4 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip">
                    <address>
                        <ip>2.2.2.1</ip>
                        <netmask>255.255.255.0</netmask>
                    </address>
                </ipv4>
                <ipv6 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip"/>
            </interface>
            <interface>
                <name>Tunnel0</name>
                <type xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">ianaift:tunnel</type>
                <enabled>true</enabled>
                <ipv4 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip">
                    <address>
                        <ip>10.10.1.1</ip>
                        <netmask>255.255.255.252</netmask>
                    </address>
                </ipv4>
                <ipv6 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip"/>
            </interface>
            <interface>
                <name>Tunnel1</name>
                <type xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">ianaift:tunnel</type>
                <enabled>true</enabled>
                <ipv4 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip"/>
                <ipv6 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip"/>
            </interface>
            <interface>
                <name>Tunnel2</name>
                <type xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">ianaift:tunnel</type>
                <enabled>true</enabled>
                <ipv4 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip"/>
                <ipv6 xmlns="urn:ietf:params:xml:ns:yang:ietf-ip"/>
            </interface>
        </interfaces>
    </data>
</rpc-reply>


The interface status of the device is: 
Interface GigabitEthernet1 enabled status is true
Interface GigabitEthernet2 enabled status is true
Interface GigabitEthernet3 enabled status is false
Interface Loopback0 enabled status is true
Interface Loopback201 enabled status is true
Interface Loopback1919 enabled status is true
Interface Tunnel0 enabled status is true
Interface Tunnel1 enabled status is true
Interface Tunnel2 enabled status is true