### PR TITLE
add the capability in the config tag to avoid error

### DIFF
--- a/intro-mdp/netconf/add_loopback.py
+++ b/intro-mdp/netconf/add_loopback.py
@@ -49,7 +49,7 @@ IETF_INTERFACE_TYPES = {
 
 # Create an XML configuration template for ietf-interfaces
 netconf_interface_template = """
-<config>
+<config xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
     <interfaces xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces">
         <interface>
         	<name>{name}</name>


### PR DESCRIPTION
error received on IOSXE 17.12.02 before adding the capability in the config tag : ''' 
ncclient.operations.rpc.RPCError: {'type': 'protocol', 'tag': 'unknown-element', 'severity': 'error', 'info': '<?xml version="1.0" encoding="UTF-8"?><error-info xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"><bad-element>config</bad-element>\n</error-info>\n', 'path': '\n    /rpc/edit-config\n  ', 'message': None}
'''